### PR TITLE
Fix bug when :drakma-no-ssl is in *features*

### DIFF
--- a/http-stream.lisp
+++ b/http-stream.lisp
@@ -90,7 +90,8 @@
               (make-instance 'as:async-io-stream :socket existing-socket))
             ;; new socket/stream
             (apply (if ssl
-                       #'as-ssl:tcp-ssl-connect
+                       #-drakma-no-ssl #'as-ssl:tcp-ssl-connect
+                       #+drakma-no-ssl (error "Drakma SSL disabled; cannot proceed with HTTPS request.")
                        #'as:tcp-connect)
                    (list 
                      host port


### PR DESCRIPTION
Right now the system may fail to compile when `:drakma-no-ssl` is in `*features*` because it implicitly relies on package `cl-async-ssl` to be present [which is not marked as a dependency when that feature is present](https://github.com/orthecreedence/drakma-async/blob/3353e5cd8c14e40ac1f21e4065b07c75065b1500/drakma-async.asd#L6).

This PR rectifies that. I chose to leave the `ssl` keyword argument because it might break some code which relies on giving it a false value.